### PR TITLE
Add tests for uncovered TodoApp and TodoForm code paths

### DIFF
--- a/app/__tests__/TodoApp.test.tsx
+++ b/app/__tests__/TodoApp.test.tsx
@@ -80,4 +80,52 @@ describe("TodoApp", () => {
       expect(highIdx).toBeLessThan(lowIdx);
     }
   });
+
+  it("adds a new todo when the form is submitted", async () => {
+    render(<TodoApp dict={dict} />);
+    await userEvent.click(screen.getByRole("button", { name: /\+ add todo/i }));
+    await userEvent.type(screen.getByPlaceholderText(/what needs to be done/i), "New test task");
+    await userEvent.click(screen.getByRole("button", { name: /^add todo$/i }));
+    expect(screen.getByText("New test task")).toBeInTheDocument();
+  });
+
+  it("cancels adding a todo and hides the form", async () => {
+    render(<TodoApp dict={dict} />);
+    await userEvent.click(screen.getByRole("button", { name: /\+ add todo/i }));
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(screen.getByRole("button", { name: /\+ add todo/i })).toBeInTheDocument();
+  });
+
+  it("toggles a todo to completed state", async () => {
+    render(<TodoApp dict={dict} />);
+    const completeButtons = screen.getAllByRole("button", { name: /mark as complete/i });
+    await userEvent.click(completeButtons[0]);
+    // After toggling, it may disappear from default view; show done to verify
+    await userEvent.click(screen.getByRole("button", { name: /show done/i }));
+    expect(screen.getAllByRole("button", { name: /mark as incomplete/i }).length).toBeGreaterThan(0);
+  });
+
+  it("deletes a todo", async () => {
+    render(<TodoApp dict={dict} />);
+    const initialCount = screen.getAllByRole("button", { name: /mark as complete/i }).length;
+    await userEvent.click(screen.getAllByRole("button", { name: /delete/i })[0]);
+    const newCount = screen.getAllByRole("button", { name: /mark as complete/i }).length;
+    expect(newCount).toBe(initialCount - 1);
+  });
+
+  it("opens edit form when edit button is clicked", async () => {
+    render(<TodoApp dict={dict} />);
+    await userEvent.click(screen.getAllByRole("button", { name: /^edit$/i })[0]);
+    expect(screen.getByRole("button", { name: /save changes/i })).toBeInTheDocument();
+  });
+
+  it("saves edited todo title", async () => {
+    render(<TodoApp dict={dict} />);
+    await userEvent.click(screen.getAllByRole("button", { name: /^edit$/i })[0]);
+    const titleInput = screen.getByPlaceholderText(/what needs to be done/i);
+    await userEvent.clear(titleInput);
+    await userEvent.type(titleInput, "Edited task title");
+    await userEvent.click(screen.getByRole("button", { name: /save changes/i }));
+    expect(screen.getByText("Edited task title")).toBeInTheDocument();
+  });
 });

--- a/app/__tests__/TodoForm.test.tsx
+++ b/app/__tests__/TodoForm.test.tsx
@@ -45,6 +45,35 @@ describe("TodoForm — add mode", () => {
   });
 });
 
+describe("TodoForm — field interactions", () => {
+  it("updates description field on input", async () => {
+    const onSubmit = vi.fn();
+    render(<TodoForm onSubmit={onSubmit} onCancel={vi.fn()} />);
+    await userEvent.type(screen.getByPlaceholderText(/description/i), "Some notes");
+    await userEvent.type(screen.getByPlaceholderText(/what needs to be done/i), "Task");
+    await userEvent.click(screen.getByRole("button", { name: /add todo/i }));
+    expect(onSubmit.mock.calls[0][0].description).toBe("Some notes");
+  });
+
+  it("submits selected priority", async () => {
+    const onSubmit = vi.fn();
+    render(<TodoForm onSubmit={onSubmit} onCancel={vi.fn()} />);
+    await userEvent.selectOptions(screen.getByDisplayValue("Medium"), "high");
+    await userEvent.type(screen.getByPlaceholderText(/what needs to be done/i), "Task");
+    await userEvent.click(screen.getByRole("button", { name: /add todo/i }));
+    expect(onSubmit.mock.calls[0][0].priority).toBe("high");
+  });
+
+  it("submits selected category", async () => {
+    const onSubmit = vi.fn();
+    render(<TodoForm onSubmit={onSubmit} onCancel={vi.fn()} />);
+    await userEvent.selectOptions(screen.getByDisplayValue("Personal"), "work");
+    await userEvent.type(screen.getByPlaceholderText(/what needs to be done/i), "Task");
+    await userEvent.click(screen.getByRole("button", { name: /add todo/i }));
+    expect(onSubmit.mock.calls[0][0].category).toBe("work");
+  });
+});
+
 describe("TodoForm — edit mode", () => {
   const existing: Todo = {
     id: "99",


### PR DESCRIPTION
## Summary
- Ran the full test suite — all 50 existing tests passed with no failures
- Added 9 new tests to cover previously untested code paths in `TodoApp` and `TodoForm`
- All 59 tests now pass

## New test coverage
**TodoApp** — add, cancel-add, toggle, delete, open-edit, and save-edit flows (handlers on lines 31–57 and the edit form branch on lines 90–101 were previously uncovered)

**TodoForm** — description field input, priority select change, and category select change (onChange handlers on lines 62–78 were previously uncovered)

## Test plan
- [x] `npm test` — 59/59 tests pass
- [x] `npm run lint` — no lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)